### PR TITLE
[BUG] Limit release creation on the workflow to master merges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
           mv .pio/build/tlora-t3s3-v1/firmware.bin .pio/build/tlora-t3s3-v1/firmware-s3.bin
                     
       - name: Create release
+        if: ${{ github.event_name != 'pull_request_target' && github.event_name != 'pull_request' }}
         uses: softprops/action-gh-release@v1
         id: create_release
         with:


### PR DESCRIPTION
**Issue**

Opening a PR against this repo will cause the "Create Release" action to trigger causing the build PR artifacts to replace the artifacts tagged as "latest".

**Suggested Fix**

Use the same mechanism used in the `meshtastic/firmware` repo to prevent `pull-request` events from triggering the `Create Release` stage so it is only triggered on merges to trunk. See: https://github.com/meshtastic/firmware/blob/master/.github/workflows/main_matrix.yml#L182