### PR TITLE
[IMPROVEMENT] Add ESP32C3 build target and release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,13 @@ jobs:
         run: |
           pio upgrade
 
-      - name: Build ESP32 + ESP32-S2
+      - name: Build ESP32 + ESP32-S2 + ESP32-C3
         run: |
           pio run -e ttgo-t-beam
           pio run -e tlora-t3s3-v1
+          pio run -e esp32c3
           mv .pio/build/tlora-t3s3-v1/firmware.bin .pio/build/tlora-t3s3-v1/firmware-s3.bin
+          mv .pio/build/esp32c3/firmware.bin .pio/build/esp32c3/firmware-c3.bin
                     
       - name: Create release
         if: ${{ github.event_name != 'pull_request_target' && github.event_name != 'pull_request' }}
@@ -73,5 +75,6 @@ jobs:
           files: |
             .pio/build/ttgo-t-beam/firmware.bin
             .pio/build/tlora-t3s3-v1/firmware-s3.bin
+            .pio/build/esp32c3/firmware-c3.bin
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32c3_out.ld"
+    },
+    "core": "esp32",
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "extra_flags": [
+      "-DARDUINO_ESP32C3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "mcu": "esp32c3",
+    "variant": "esp32c3"
+  },
+  "connectivity": ["wifi", "bluetooth"],
+  "debug": {
+    "openocd_target": "esp32c3.cfg"
+  },
+  "serial": {
+    "disableDTR": true,
+    "disableRTS": true
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "esp32c3",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html",
+  "vendor": "Espressif"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,6 +33,12 @@ build_flags =
   -DCONFIG_NIMBLE_CPP_LOG_LEVEL=2
   -DCONFIG_BT_NIMBLE_MAX_CCCDS=20
 
+[esp32c3_base]
+extends = esp32_base
+board = esp32c3
+monitor_speed = 115200
+monitor_filters = esp32_c3_exception_decoder
+
 [env:ttgo-t-beam]
 extends = esp32_base
 board = ttgo-t-beam
@@ -43,3 +49,10 @@ board = tlora-t3s3-v1
 build_flags = 
   ${esp32_base.build_flags} 
   -Isrc/esp32s3
+
+[env:esp32c3]
+extends = esp32c3_base
+build_flags =
+  ${esp32c3_base.build_flags}
+upload_protocol = esptool
+upload_speed = 460800


### PR DESCRIPTION
**Issue**

The current published `bleota.bin` releases cover the ESP32 and ESP32-S3 series of microcontrollers. The ESP32-C3 has a RISC-V code so the existing firmwares will not work on that platform.

**Proposed Solution**

Add an `esp32c3` build target and publish the resulting `firmware-c3.bin` that can be consumed by the `device-install.sh` scripts if desired.

**Testing**

Tested using a DIY `esp32c3` device and a custom built meshtastic firmware and `bleota.bin` flashed to the device with the `device-install.sh` script. The device is rebooted into the OTA firmware via `meshtastic --reboot-ota`. The OTA update was done using https://github.com/titan098/meshtastic-ble-ota to test the OTA workflow.

Serial log of the OTA update:
```
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x3 (RTC_SW_SYS_RST),boot:0xf (SPI_FAST_FLASH_BOOT)
Saved PC:0x403820d6
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd5810,len:0x38c
load:0x403cc710,len:0x6b0
load:0x403ce710,len:0x25b0
entry 0x403cc710
E (159) esp_core_dump_flash: No core dump partition found!
E (159) esp_core_dump_flash: No core dump partition found!


//\ E S H T /\ S T / C Failsafe OTA

ESP32 Chip model = 4
This chip has 160 MHz
Setting random seed 2836634474
Total heap: 284852
Free heap: 256552
Total PSRAM: 0
Free PSRAM: 0
NVS: UsedEntries 70, FreeEntries 560, AllEntries 630, NameSpaces 3
Number of Device Reboots: 1
Filesystem files (24576/1048576 Bytes):
/prefs/channels.proto (57 Bytes)
/prefs/db.proto (118 Bytes)
/static/.gitkeep (0 Bytes)
Loading /prefs/db.proto
Loaded saved devicestate version 22
Hardware Model: 255
Main Firmware Version: 
BLE name: Meshtastic_857c
Waiting a client connection to notify...
*** App connected
a4:c3:f0:88:94:6e
main loop started
Writing to partition subtype 16 at offset 0x10000 
--Data received---
--Data received---
--Data received---
...
--Data received---
Final byte arrived
Set Boot partion
Restarting...
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x3 (RTC_SW_SYS_RST),boot:0xf (SPI_FAST_FLASH_BOOT)
Saved PC:0x403819c6
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd5810,len:0x38c
load:0x403cc710,len:0x6b0
load:0x403ce710,len:0x25b0
entry 0x403cc710
E (396) esp_core_dump_flash: No core dump partition found!
E (397) esp_core_dump_flash: No core dump partition found!
��@INFO  | ??:??:?? 0 

//\ E S H T /\ S T / C

INFO  | ??:??:?? 0 Booted, wake cause 0 (boot count 1), reset_reason=reset
DEBUG | ??:??:?? 0 Filesystem files (24576/1048576 Bytes):
DEBUG | ??:??:?? 0  /prefs/channels.proto (57 Bytes)
DEBUG | ??:??:?? 0  /prefs/db.proto (118 Bytes)
DEBUG | ??:??:?? 0  /static/.gitkeep (0 Bytes)
[   479][I][esp32-hal-i2c.c:75] i2cInit(): Initialising I2C Master: sda=8 scl=9 freq=100000
INFO  | ??:??:?? 0 Scanning for i2c devices...
[   482][W][Wire.cpp:301] begin(): Bus already started in Master Mode.
...
```